### PR TITLE
Support '/' in branch names

### DIFF
--- a/docker/maven_build/Dockerfile
+++ b/docker/maven_build/Dockerfile
@@ -6,6 +6,10 @@ FROM maven:3.8-jdk-11-slim
 
 WORKDIR /tmp
 
+# Registry Common jars
+ADD pom/registry_common/pom.xml /tmp/
+RUN mvn verify --fail-never && mvn clean && rm -rf /tmp/pom.xml
+
 # Harvest jars
 ADD pom/harvest/pom.xml /tmp/
 RUN mvn verify --fail-never && mvn clean && rm -rf /tmp/pom.xml

--- a/docker/maven_build/entrypoint.sh
+++ b/docker/maven_build/entrypoint.sh
@@ -23,7 +23,7 @@ harvest)
     echo "Building Harvest ..."
     git clone https://github.com/NASA-PDS/harvest.git
     cd harvest
-    git checkout $BRANCH
+    git checkout "$BRANCH"
     if [ $? != 0 ]; then exit 1; fi
     mvn package
     cp target/harvest-*-bin.tar.gz /build
@@ -32,7 +32,7 @@ manager)
     echo "Building Registry Manager ..."
     git clone https://github.com/NASA-PDS/pds-registry-mgr-elastic.git
     cd pds-registry-mgr-elastic
-    git checkout $BRANCH
+    git checkout "$BRANCH"
     if [ $? != 0 ]; then exit 1; fi
     mvn package
     cp target/registry-manager-*-bin.tar.gz /build
@@ -41,7 +41,7 @@ api)
     echo "Building Registry API ..."
     git clone https://github.com/NASA-PDS/registry-api-service.git
     cd registry-api-service
-    git checkout $BRANCH
+    git checkout "$BRANCH"
     if [ $? != 0 ]; then exit 1; fi
     mvn package
     cp target/registry-api-service-*-bin.tar.gz /build

--- a/docker/maven_build/pom/api/pom.xml
+++ b/docker/maven_build/pom/api/pom.xml
@@ -1,10 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gov.nasa.pds</groupId>
 	<artifactId>registry-api-service</artifactId>
-	<version>0.1.0</version>
+	<version>0.4.0-SNAPSHOT</version>
 	<name>gov.nasa.pds.api.registry-service</name>
 	<description>registry api service contributing to the PDS federated API</description>
 	<properties>
@@ -19,7 +17,7 @@
 		<!-- >version>1.5.9.RELEASE</version -->
 	</parent>
 	<build>
-		<sourceDirectory>src</sourceDirectory>
+		<!-- <sourceDirectory>src</sourceDirectory> -->
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
@@ -84,11 +82,12 @@
 	    </site>
 	</distributionManagement>
 
-	<scm>
-		<url>https://github.com/NASA-PDS/registry-api-service/tree/master</url>
-		<connection>scm:git:git://github.com/NASA-PDS/registry-api-service.git</connection>
-		<developerConnection>scm:git:ssh://github.com:NASA-PDS/registry-api-service.git</developerConnection>
-	</scm>
+        <scm>
+		<url>https://github.com/NASA-PDS/registry-api-service</url>
+		<connection>scm:git:git@github.com/NASA-PDS/registry-api-service.git</connection>
+		<developerConnection>scm:git:git@github.com:NASA-PDS/registry-api-service.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
 
 
 	<dependencies>
@@ -201,7 +200,28 @@
 			<artifactId>joda-time</artifactId>
 			<version>2.10.6</version>
 		</dependency>
-		
+
+                <dependency>
+                  <groupId>com.sun.xml.bind</groupId>
+                  <artifactId>jaxb-core</artifactId>
+                  <version>2.3.0.1</version>
+                </dependency>
+                <dependency>
+                  <groupId>javax.xml.bind</groupId>
+                  <artifactId>jaxb-api</artifactId>
+                  <version>2.3.1</version>
+                </dependency>
+                <dependency>
+                  <groupId>com.sun.xml.bind</groupId>
+                  <artifactId>jaxb-impl</artifactId>
+                  <version>2.3.1</version>
+                </dependency>
+                <dependency>
+                  <groupId>org.javassist</groupId>
+                  <artifactId>javassist</artifactId>
+                  <version>3.25.0-GA</version>
+                </dependency>
+	
 		<!--  used to force a specific namespace in the XML serialization -->
 		<dependency>
 		  <groupId>org.codehaus.woodstox</groupId>
@@ -220,13 +240,13 @@
 		<dependency>
 			<groupId>gov.nasa.pds</groupId>
 			<artifactId>api</artifactId>
-			<version>0.2.0-SNAPSHOT</version>
+			<version>0.4.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>gov.nasa.pds</groupId>
 			<artifactId>api-search-query-lexer</artifactId>
-			<version>0.2.0-SNAPSHOT</version>
+			<version>0.2.0</version>
 		</dependency>
 
 		<dependency>

--- a/docker/maven_build/pom/harvest/pom.xml
+++ b/docker/maven_build/pom/harvest/pom.xml
@@ -92,17 +92,6 @@
             <artifactId>commons-codec</artifactId>
             <version>1.15</version>
         </dependency>
-        <!-- Log4j logger -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.13.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.13.2</version>
-        </dependency>
         <!-- File type detection -->
         <dependency>
             <groupId>org.apache.tika</groupId>
@@ -119,7 +108,7 @@
         <dependency>
             <groupId>gov.nasa.pds</groupId>
             <artifactId>registry-common</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/docker/maven_build/pom/manager/pom.xml
+++ b/docker/maven_build/pom/manager/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>gov.nasa.pds</groupId>
             <artifactId>registry-common</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <!-- JSON parser -->
         <dependency>

--- a/docker/maven_build/pom/registry_common/pom.xml
+++ b/docker/maven_build/pom/registry_common/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Inherit release profile, reporting, SNAPSHOT repo, etc. from parent repo -->
+    <parent>
+        <groupId>gov.nasa</groupId>
+        <artifactId>pds</artifactId>
+        <version>1.8.0</version>
+    </parent>
+    
+    <groupId>gov.nasa.pds</groupId>
+    <artifactId>registry-common</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    
+    <name>PDS Registry Common</name>
+    <description>
+        Common code used by Harvest and Registry Manager.
+    </description>
+        
+    <organization>
+        <name>Jet Propulsion Laboratory, California Institute of Technology</name>
+    </organization>
+    
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- Elasticsearch client-->
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-client</artifactId>
+            <version>7.10.2</version>
+        </dependency>
+        <!-- JSON parser -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
+        </dependency>
+        <!-- Log4j logger -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.13.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.13.3</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Disable Site for now -->
+            <plugin>
+                <artifactId>maven-site-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                    <skipDeploy>true</skipDeploy>
+                </configuration>
+            </plugin>
+            <!-- Java Docs -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <detectJavaApiLink>false</detectJavaApiLink>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+  <scm>
+    <url>https://github.com/NASA-PDS/pds-registry-common</url>
+    <connection>scm:git:git@github.com/NASA-PDS/pds-registry-common.git</connection>
+    <developerConnection>scm:git:git@github.com:NASA-PDS/pds-registry-common.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+</project>


### PR DESCRIPTION
See https://github.com/NASA-PDS/registry-ci/issues/2

**Changes**
(1) Fixed `entrypoint.sh` in /docker/maven_build
(2) Updated (copied) latest POMs from upstream projects. 🤷 Could not do anything about Sonatype warnings.

**Test Instructions**
- Checkout the project
- Go to `registry-ci/docker/maven_build`
- Run
```
mkdir -p /tmp/build
docker build -t pds_maven_build:1.0 .
docker run --rm --name registry-build -v /tmp/build:/build pds_maven_build:1.0 api "release/v0.3"
```
**NOTE:** If you don't want to build docker image yourself you can reuse my image:
```
docker run --rm --name registry-build -v /tmp/build:/build tdddblog/pds_maven_build:1.0 api "release/v0.3"
```
- Check that `registry-api-service-x.x.x-bin.tar.gz` was created in `/tmp/build/`

